### PR TITLE
Fix None hotkey check

### DIFF
--- a/HunterPie.Core/Input/Hotkey.cs
+++ b/HunterPie.Core/Input/Hotkey.cs
@@ -68,7 +68,7 @@ namespace HunterPie.Core.Input
             else
             {
                 // Skip hotkeys which value is "None"
-                if (hotkey[0] == 0 && hotkey[0] == 0)
+                if (hotkey[0] == 0 && hotkey[1] == 0)
                 {
                     return 0;
                 }


### PR DESCRIPTION
It looks like the conditional does a mod + mod check instead of mod + key