### PR TITLE
Add "requires restart" label for localization

### DIFF
--- a/HunterPie.Core/Client/Configuration/ClientConfig.cs
+++ b/HunterPie.Core/Client/Configuration/ClientConfig.cs
@@ -18,7 +18,7 @@ namespace HunterPie.Core.Client.Configuration
         [SettingField("SUPPORTER_SECRET_TOKEN_STRING")]
         public Secret SupporterSecretToken { get; set; } = new();
 
-        [SettingField("LANGUAGE_STRING")]
+        [SettingField("LANGUAGE_STRING", requiresRestart: true)]
         public GenericFileSelector Language { get; set; } = new GenericFileSelector("en-us.xml", "*.xml", ClientInfo.LanguagesPath);
 
         [SettingField("MINIMIZE_TO_SYSTEM_TRAY_STRING")]


### PR DESCRIPTION
Unless I'm missing something, switching languages requires a restart. This PR adds "Requires restart" label to this option. I can't really test it myself but I hope i did the right thing :3