### PR TITLE
Fix(Core|UI): Prevent very large DPS data points being calculated when entering the quest

### DIFF
--- a/HunterPie.Core/Game/Client/IPartyMember.cs
+++ b/HunterPie.Core/Game/Client/IPartyMember.cs
@@ -14,6 +14,9 @@ public interface IPartyMember
     public bool IsMyself { get; }
     public MemberType Type { get; }
 
+    /// <summary>Manually reset damage data.</summary>
+    public void ResetDamage();
+
     public event EventHandler<IPartyMember> OnDamageDealt;
     public event EventHandler<IPartyMember> OnWeaponChange;
 }

--- a/HunterPie.Core/Game/Demos/Sunbreak/MHRSunbreakDemoGame.cs
+++ b/HunterPie.Core/Game/Demos/Sunbreak/MHRSunbreakDemoGame.cs
@@ -39,7 +39,7 @@ public class MHRSunbreakDemoGame : Scannable, IGame, IEventDispatcher
     public event EventHandler<IMonster> OnMonsterSpawn;
     public event EventHandler<IMonster> OnMonsterDespawn;
     public event EventHandler<IGame> OnHudStateChange;
-    public event EventHandler<IGame> OnTimeElapsedChange;
+    public event EventHandler<TimeElapsedChangeEventArgs> OnTimeElapsedChange;
     public event EventHandler<IGame> OnDeathCountChange;
 
     public MHRSunbreakDemoGame(IProcessManager process) : base(process)

--- a/HunterPie.Core/Game/IGame.cs
+++ b/HunterPie.Core/Game/IGame.cs
@@ -21,6 +21,6 @@ public interface IGame : IDisposable
     public event EventHandler<IMonster> OnMonsterSpawn;
     public event EventHandler<IMonster> OnMonsterDespawn;
     public event EventHandler<IGame> OnHudStateChange;
-    public event EventHandler<IGame> OnTimeElapsedChange;
+    public event EventHandler<TimeElapsedChangeEventArgs> OnTimeElapsedChange;
     public event EventHandler<IGame> OnDeathCountChange;
 }

--- a/HunterPie.Core/Game/Rise/Entities/Party/MHRPartyMember.cs
+++ b/HunterPie.Core/Game/Rise/Entities/Party/MHRPartyMember.cs
@@ -48,6 +48,12 @@ public class MHRPartyMember : IPartyMember, IEventDispatcher, IUpdatable<MHRPart
 
     public int MasterRank { get; private set; }
 
+    /// <inheritdoc />
+    public void ResetDamage()
+    {
+        _damage = 0;
+    }
+
     public event EventHandler<IPartyMember> OnDamageDealt;
     public event EventHandler<IPartyMember> OnWeaponChange;
 

--- a/HunterPie.Core/Game/Rise/MHRGame.cs
+++ b/HunterPie.Core/Game/Rise/MHRGame.cs
@@ -63,7 +63,7 @@ public class MHRGame : Scannable, IGame, IEventDispatcher, IDisposable
             if (value != _timeElapsed)
             {
                 _timeElapsed = value;
-                this.Dispatch(OnTimeElapsedChange, this);
+                this.Dispatch(OnTimeElapsedChange, TimeElapsedChangeEventArgs.Empty);
             }
         }
     }
@@ -84,7 +84,7 @@ public class MHRGame : Scannable, IGame, IEventDispatcher, IDisposable
     public event EventHandler<IMonster> OnMonsterSpawn;
     public event EventHandler<IMonster> OnMonsterDespawn;
     public event EventHandler<IGame> OnHudStateChange;
-    public event EventHandler<IGame> OnTimeElapsedChange;
+    public event EventHandler<TimeElapsedChangeEventArgs> OnTimeElapsedChange;
     public event EventHandler<IGame> OnDeathCountChange;
 
     public MHRGame(IProcessManager process) : base(process)

--- a/HunterPie.Core/Game/TimeElapsedChangeEventArgs.cs
+++ b/HunterPie.Core/Game/TimeElapsedChangeEventArgs.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace HunterPie.Core.Game;
+
+public class TimeElapsedChangeEventArgs : EventArgs
+{
+    public new static readonly TimeElapsedChangeEventArgs Empty = new(false);
+
+    public static readonly TimeElapsedChangeEventArgs TimerReset = new(true);
+
+    public TimeElapsedChangeEventArgs(bool isTimerReset)
+    {
+        IsTimerReset = isTimerReset;
+    }
+
+    /// <summary>
+    /// Whether the timer has been reset (and switched) into another zero or some non-zero value.
+    /// This indicates the time elapsed may experience sudden change.
+    /// </summary>
+    public bool IsTimerReset { get; }
+}

--- a/HunterPie.Core/Game/World/Entities/Party/MHWPartyMember.cs
+++ b/HunterPie.Core/Game/World/Entities/Party/MHWPartyMember.cs
@@ -50,6 +50,13 @@ public class MHWPartyMember : IPartyMember, IEventDispatcher, IUpdatable<MHWPart
 
     public int MasterRank { get; private set; }
 
+    /// <inheritdoc />
+    public void ResetDamage()
+    {
+        _damage = 0;
+        _anyNonTrivialStatisticalDamage = false;
+    }
+
     public event EventHandler<IPartyMember> OnDamageDealt;
     public event EventHandler<IPartyMember> OnWeaponChange;
 

--- a/HunterPie.Core/Game/World/MHWGame.cs
+++ b/HunterPie.Core/Game/World/MHWGame.cs
@@ -254,6 +254,11 @@ public class MHWGame : Scannable, IGame, IEventDispatcher
 
     private void OnPlayerStageUpdate(object sender, EventArgs e)
     {
+        if (!Player.InHuntingZone)
+        {
+            // When back from hunt, manually clear damage data in case player enters Training Area (data won't be reset)
+            foreach (var member in Player.Party.Members) member.ResetDamage();
+        }
         DamageMessageHandler.ClearAllHuntStatisticsExcept(Array.Empty<long>());
         DamageMessageHandler.RequestHuntStatistics(ALL_TARGETS);
         _damageUpdateThrottleStopwatch.Reset();

--- a/HunterPie.UI/Overlay/Widgets/Damage/MemberInfo.cs
+++ b/HunterPie.UI/Overlay/Widgets/Damage/MemberInfo.cs
@@ -7,6 +7,6 @@ internal class MemberInfo
 {
     public PlayerViewModel ViewModel { get; init; }
     public Series Series { get; init; }
-    public double JoinedAt { get; init; }
+    public double JoinedAt { get; set; }
     public double FirstHitAt { get; set; } = -1;
 }


### PR DESCRIPTION
When game's real quest timer gets ready, or switching between local quest timer and game's real quest timer, clears the damage chart and reset party member's `JoinedAt` with the following rules
* If the member is the local player, set `JoinedAt` to the current quest timer value
* For other party members, set `JoinedAt` to zero.

This prevents very large DPS points being drawn on the damage chart especially when the hunting party info (incl. damage dealt) gets ready before the in-game timer readies.

Currently, this change only applies to MHW. `MHRGame` needs to emit `OnTimeElapsedChange` with `IsTimerReset = true` to notify `DamageMeterWidgetContextHandler` the timer has been reset.

This PR also reset local player's damage data when they returns from hunts, so they won't see the remnant damage number from last hunt, and large DPS number when they goes to Training Area.
