### PR TITLE
Fix(Core): Fix regression of very large DPS data points being calculated when joining other players' quests

### DIFF
--- a/HunterPie.Core/Game/TimeElapsedChangeEventArgs.cs
+++ b/HunterPie.Core/Game/TimeElapsedChangeEventArgs.cs
@@ -4,8 +4,6 @@ namespace HunterPie.Core.Game;
 
 public class TimeElapsedChangeEventArgs : EventArgs
 {
-    public static readonly TimeElapsedChangeEventArgs TimerReset = new(true, 0.0f);
-
     public TimeElapsedChangeEventArgs(bool isTimerReset, float timeElapsed)
     {
         IsTimerReset = isTimerReset;

--- a/HunterPie.Core/Game/World/MHWGame.cs
+++ b/HunterPie.Core/Game/World/MHWGame.cs
@@ -65,7 +65,7 @@ public class MHWGame : Scannable, IGame, IEventDispatcher
             return;
 
         TimeElapsed = value;
-        this.Dispatch(OnTimeElapsedChange, isReset ? TimeElapsedChangeEventArgs.TimerReset : new TimeElapsedChangeEventArgs(false, TimeElapsed));
+        this.Dispatch(OnTimeElapsedChange, new TimeElapsedChangeEventArgs(isReset, value));
     }
 
     public int Deaths


### PR DESCRIPTION
Prevent `TimeElapsedChangeEventArgs.TimeElapsed` from being 0.0 when `IsTimerReset == true`.
